### PR TITLE
feat: Initial Browser MCP Agent CLI structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,28 @@
+# Ignore Node.js modules
+node_modules/
+
+# Ignore package lock files
+package-lock.json
+npm-shrinkwrap.json
+yarn.lock
+pnpm-lock.yaml
+
+# Ignore OS-generated files
+.DS_Store
+Thumbs.db
+
+# Ignore log files
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+
+# Ignore editor directories and files
+.idea
+.vscode
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/README.md
+++ b/README.md
@@ -1,0 +1,95 @@
+# Browser MCP Agent
+
+This Node.js application provides a command-line interface (CLI) to interact with the Browser MCP (Model Context Protocol) server. It allows you to send commands to control your Chrome browser autonomously, provided the Browser MCP extension is installed in Chrome and the Browser MCP server is running.
+
+## Prerequisites
+
+1.  **Node.js**: Ensure Node.js is installed on your system. You can download it from [https://nodejs.org/](https://nodejs.org/).
+2.  **Browser MCP Chrome Extension**: Install the "Browser MCP" extension from the Chrome Web Store.
+3.  **Browser MCP Server**: The Browser MCP server must be running. Typically, you start this using `npx @browsermcp/mcp@latest` in your terminal.
+4.  **Connect Extension to Server**: Open the Browser MCP extension in Chrome and ensure it's connected to the running MCP server.
+
+## Setup
+
+1.  **Clone the repository (if applicable) or download the files.**
+    If this agent is part of a larger project or repository:
+    ```bash
+    git clone <repository-url>
+    cd <repository-directory>
+    ```
+    If you just have `agent.js` and `package.json`:
+    Ensure `agent.js`, `package.json`, and `.gitignore` are in the same directory.
+
+2.  **Install dependencies:**
+    Navigate to the project directory in your terminal and run:
+    ```bash
+    npm install
+    ```
+    This will install the necessary packages, including `@browsermcp/mcp` (which contains the server logic and potentially client utilities we might use later).
+
+## Running the Agent CLI
+
+1.  **Start the Browser MCP Server:**
+    Open a new terminal window/tab and run:
+    ```bash
+    npx @browsermcp/mcp@latest
+    ```
+    Keep this server running. Note the port it's running on (it might show in its startup logs, or it might use a default like 61000 or another port specific to BrowserMCP).
+
+2.  **Connect the Chrome Extension:**
+    - Open Chrome.
+    - Click on the Browser MCP extension icon.
+    - Ensure it shows "Connected" or follow its UI to connect to the server you just started. The tab you want to control should be active and connected via the extension.
+
+3.  **Run the Agent CLI:**
+    Open another terminal window/tab, navigate to this project's directory, and run:
+    ```bash
+    node agent.js
+    ```
+
+4.  **Interact with the CLI:**
+    You will see a prompt `mcp-agent>`. Type your commands here.
+    For example:
+    ```
+    mcp-agent> Go to google.com and search for cats
+    ```
+    The agent will then (eventually, once fully implemented) send this command to the Browser MCP server, which will execute it in your Chrome browser.
+
+    To quit the agent CLI, type:
+    ```
+    mcp-agent> exit
+    ```
+
+## How it Works (Current Stage)
+
+-   `agent.js`: This is the main script for the CLI.
+    - It uses Node.js's `readline` module to get user input.
+    - It currently has a placeholder function (`sendCommandToMcpServer`) that simulates sending commands. The actual communication logic with the Browser MCP server is yet to be fully implemented.
+-   Browser MCP Server (`@browsermcp/mcp`): This is a separate process that needs to be running. It listens for commands.
+-   Browser MCP Chrome Extension: This extension, running in your browser, connects to the Browser MCP server and executes the commands it receives on the currently active/connected browser tab.
+
+## Future Development
+
+-   Implement the `sendCommandToMcpServer` function in `agent.js` to establish a proper connection with the running Browser MCP server (likely using client libraries from `@modelcontextprotocol/sdk` or utilities exposed by `@browsermcp/mcp`).
+-   Determine the correct port and communication protocol for the Browser MCP server.
+-   Handle responses and errors from the MCP server more robustly.
+-   Add more sophisticated command parsing or options if needed.
+
+## Troubleshooting
+
+-   **"Error: connect ECONNREFUSED" (or similar in `sendCommandToMcpServer` once implemented):**
+    - Ensure the Browser MCP server (`npx @browsermcp/mcp@latest`) is running.
+    - Verify the port number used by the client matches the one the server is listening on.
+    - Check firewall settings if the server and client are on different machines (though typically they run on the same machine).
+-   **Commands don't execute in Chrome:**
+    - Ensure the Browser MCP Chrome extension is installed, enabled, and connected to the server.
+    - Make sure the correct tab in Chrome is active and connected via the extension's UI.
+    - Check the Browser MCP server's console output for any errors or logs.
+-   **`npm install` issues:**
+    - Ensure you have a stable internet connection.
+    - Try removing `node_modules` and `package-lock.json` and running `npm install` again.
+    ```bash
+    rm -rf node_modules package-lock.json
+    npm install
+    ```
+    (Use `rd /s /q node_modules` and `del package-lock.json` on Windows CMD).

--- a/agent.js
+++ b/agent.js
@@ -1,0 +1,79 @@
+const readline = require('readline');
+// We will need to import client functionalities from @modelcontextprotocol/sdk or @browsermcp/mcp
+// For example: const { McpClient } = require('@modelcontextprotocol/sdk'); // This is a guess
+
+// Placeholder for MCP client and command sending logic
+// This function will eventually connect to the Browser MCP server and send commands.
+async function sendCommandToMcpServer(command) {
+  console.log(`Attempting to send command (actual MCP communication not yet implemented): "${command}"`);
+  // TODO:
+  // 1. Ensure the Browser MCP server is running (e.g. `npx @browsermcp/mcp@latest`).
+  //    The server usually runs on a specific port (e.g., 61000 by default for playwright-mcp,
+  //    need to confirm for browsermcp or make it configurable).
+  // 2. Use an MCP client to connect to this server.
+  // 3. Format the command in the way the Browser MCP server expects.
+  //    This might be a JSON object with a specific structure.
+  //    For example: { "type": "BROWSER_COMMAND", "payload": { "action": "navigateToUrl", "url": "google.com" } }
+  //    Or it might directly take the natural language command: "Go to google.com"
+  //    The BrowserMCP documentation example "Go to google.com and search for 'Browser MCP'"
+  //    suggests it can take natural language.
+  // 4. Send the command and await a response.
+  // 5. Return the response or handle errors.
+
+  // Simulating a response for now.
+  return `Simulated response for command: "${command}"`;
+}
+
+async function main() {
+  console.log('Browser MCP Agent CLI');
+  console.log("----------------------");
+  console.log("Type your command to control the browser, or type 'exit' to quit.");
+  console.log("Example: 'Go to google.com and search for Browser MCP'");
+  console.log("Important: Ensure the Browser MCP server is running and the Chrome extension is connected.");
+  console.log("You can typically start the server with: npx @browsermcp/mcp@latest");
+  console.log("");
+
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+    prompt: 'mcp-agent> '
+  });
+
+  rl.prompt();
+
+  rl.on('line', async (line) => {
+    const command = line.trim();
+
+    if (command.toLowerCase() === 'exit') {
+      console.log('Exiting MCP Agent CLI.');
+      rl.close();
+      return;
+    }
+
+    if (command) {
+      try {
+        console.log(`Processing command: "${command}"`);
+        const response = await sendCommandToMcpServer(command);
+        console.log(`Server response: ${response}`);
+      } catch (error) {
+        console.error(`Error processing command: ${error.message}`);
+        console.error(error.stack);
+      }
+    }
+    // Only re-prompt if the readline interface is still active and not about to close.
+    // rl.closing becomes true once rl.close() is called.
+    if (rl.readable && rl.writable && !rl.closing) {
+        rl.prompt();
+    }
+  });
+
+  rl.on('close', () => {
+    console.log('CLI session ended.');
+    process.exit(0);
+  });
+}
+
+main().catch(error => {
+  console.error("Critical error in main function:", error);
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "app",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/matt793/MCP-Browser-Gemain-App.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "bugs": {
+    "url": "https://github.com/matt793/MCP-Browser-Gemain-App/issues"
+  },
+  "homepage": "https://github.com/matt793/MCP-Browser-Gemain-App#readme",
+  "dependencies": {
+    "@browsermcp/mcp": "^0.1.3"
+  }
+}


### PR DESCRIPTION
Sets up a Node.js project for an agent that will control a Chrome browser via the Browser MCP extension and server.

Includes:
- Basic CLI using readline to accept user commands.
- Placeholder for sending commands to the MCP server.
- .gitignore for Node.js projects.
- README.md with setup and usage instructions.

The core functionality of communicating with the Browser MCP server is yet to be implemented in `sendCommandToMcpServer`.